### PR TITLE
Changes to support Android.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+maximo-restclient.iml
+target/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 3. Add support to bulk for ResourceSet
 4. Add new examples about new API in TestOSLCAPI.java.
 5. Fix bugs
+6. Removed references to `javax.xml.bind.DatatypeConverter.printBase64Binary` since that API is not available on Android.  It now uses commons-codec to get base64 support.
 
 # Maximo Rest Client 1.0 Released!
 
@@ -64,7 +65,7 @@ Last Release
 
 If the Internet is unavailable or it is difficult to access the central repository for some reason. The client can be installed locally. After the installation, it can be included in a Maven project as well.
 
-1. Run mvn clean install at the dictionary of library.
+1. Run `mvn clean install -Dgpg.skip` at the dictionary of library.
 2. Create a new Maven project
 3. Add following dependency to your pom.xml file
 
@@ -72,13 +73,15 @@ If the Internet is unavailable or it is difficult to access the central reposito
 <dependency>
 	<groupId>com.ibm.maximo</groupId>
 	<artifactId>maximo-restclient</artifactId>
-	<version>0.1</version>
+	<version>VERSION</version>
 </dependency>
 ```
 
+Where VERSION is the version you gave this artifact in the `pom.xml`
+
 ## 2.2 As a Java library
 
-If the Maven environment is unavailable. The Maximo Rest Client can be used as a regular reference library in Java project. As the client depends on javax-json, the javax-json library is needed as well.
+If the Maven environment is unavailable. The Maximo Rest Client can be used as a regular reference library in Java project. As the client depends on javax-json, the javax-json and commons-codec libraries is needed as well.
 
 You can get it from http://repo1.maven.org/maven2/org/glassfish/javax.json/1.0.4/ or use the Maven dependency as,
 
@@ -88,9 +91,15 @@ You can get it from http://repo1.maven.org/maven2/org/glassfish/javax.json/1.0.4
     <artifactId>javax.json</artifactId>
     <version>1.0.4</version>
 </dependency>
+<dependency>
+	<groupId>commons-codec</groupId>
+	<artifactId>commons-codec</artifactId>
+	<version>1.1</version>
+</dependency>
+
 ```
 
-When the javax.json-1.0.4.jar and maximo-restclient-0.1.jar is ready, add them to the java project as commen reference libraries.
+When the javax.json-1.0.4.jar, commons-codec-1.1.jar and maximo-restclient-0.1.jar is ready, add them to the java project as common reference libraries.
 	
 # III. Usage
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ibm.maximo</groupId>
 	<artifactId>maximo-restclient</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 
 	<name>maximo-rest-client</name>
 	<description>The Maximo REST client library provides a set of driver API's which can be consumed by an JAVA based web component that would like to interface with a Maximo instance</description>
@@ -41,6 +41,11 @@
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.json</artifactId>
 			<version>1.0.4</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ibm.maximo</groupId>
 	<artifactId>maximo-restclient</artifactId>
-	<version>1.1</version>
+	<version>1.0.2</version>
 
 	<name>maximo-rest-client</name>
 	<description>The Maximo REST client library provides a set of driver API's which can be consumed by an JAVA based web component that would like to interface with a Maximo instance</description>

--- a/src/com/ibm/maximo/oslc/MaximoConnector.java
+++ b/src/com/ibm/maximo/oslc/MaximoConnector.java
@@ -988,7 +988,8 @@ public class MaximoConnector {
 	
 	public static String encode(String userName, String password)
 			throws UnsupportedEncodingException {
-		return (javax.xml.bind.DatatypeConverter.printBase64Binary((userName
+
+		return (Util.base64Encode((userName
 				+ ":" + password).getBytes("UTF-8")));
 	}
 

--- a/src/com/ibm/maximo/oslc/Util.java
+++ b/src/com/ibm/maximo/oslc/Util.java
@@ -9,6 +9,8 @@
  */
 
 package com.ibm.maximo.oslc;
+import org.apache.commons.codec.binary.Base64;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -157,5 +159,13 @@ public class Util {
 			strb.append(ch);
 		}
 		System.out.println(strb.toString());
+	}
+
+	public static String base64Encode(String in) throws UnsupportedEncodingException {
+		return new String(Base64.encodeBase64(in.getBytes("UTF-8")));
+	}
+
+	public static String base64Encode(byte[] in) {
+		return new String(Base64.encodeBase64(in));
 	}
 }


### PR DESCRIPTION
While Android uses Java 1.8 it does not include the full suite of Java APIs.  This change refactors the code to use commons-codec for base64 support which can be used on Android and any other java application.