### PR TITLE
Fix MaximoConnector#setCookiesForSession to handle multiple cookies

### DIFF
--- a/src/com/ibm/maximo/oslc/MaximoConnector.java
+++ b/src/com/ibm/maximo/oslc/MaximoConnector.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1130,8 +1131,12 @@ public class MaximoConnector {
 	}
 
 	private void setCookiesForSession(HttpURLConnection con) {
-		for (String cookie : cookies) {
-			con.setRequestProperty("Cookie", cookie.split(";", 1)[0]);
+		if (this.cookies.size() > 0) {
+			List<String> cookieList = new ArrayList<>();
+			for (String cookie : cookies) {
+				cookieList.add(cookie.split(";", 1)[0]);
+			}
+			con.setRequestProperty("Cookie", String.join(";", cookieList));
 		}
 	}
 	


### PR DESCRIPTION
The actual implementation does not handle multiple cookies set by server.

In the context of using HTTPS to request maximo rest api, I stumbled upon the case where multiple cookies where set  JSESSIONID plus another secure cookie (Not sure if it's maximo or some proxy which handle the ssl part).
In my case the JSESSIONID cookie was not send in favor of the other cookie.

This pull request simply assure every cookies set by server are added to subsequent requests.