### PR TITLE
Form based authentication with lean=1 does not work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.2</version>
 
 	<name>maximo-rest-client</name>
-	<description>The Maximo REST client library provides a set of driver API's which can be consumed by an JAVA based web component that would like to interface with a Maximo instance</description>
+	<description>The IBM Maximo REST client library provides a set of driver API's which can be consumed by an Java-based web component that would like to interface with a Maximo instance.</description>
 	<url>http://www.ibm.com</url>
 
 	<licenses>

--- a/src/com/ibm/maximo/oslc/MaximoConnector.java
+++ b/src/com/ibm/maximo/oslc/MaximoConnector.java
@@ -1029,7 +1029,12 @@ public class MaximoConnector {
 				return con;
 			} else if (options.isFormAuth()) {
 				String appURI = uri;
-				appURI += "/j_security_check";
+				if (isLean()){
+					appURI = appURI.replace("?&lean=1", "/j_security_check?&lean=1");
+				}
+				else {
+					appURI += "/j_security_check";
+				}
 				URL httpURL = new URL(appURI);
 				HttpURLConnection con = null;
 				if(proxy != null){


### PR DESCRIPTION
For Form based authentication, the uri generated is `http://host:port/maximo/oslc` which is fine but when lean=1
then the URL turns into `http://host:port/maximo/oslc?&lean=1/j_security_check` which is incorrect. 
It should be `http://host:port/maximo/oslc/j_security_check?&lean=1`. This does not generate the required authentication cookies and the library is not usable for such cases. 
This pull requests fixes that.